### PR TITLE
Fix Google Maps Embed API referrer policy

### DIFF
--- a/deployed_site/gallery.html.tmpl
+++ b/deployed_site/gallery.html.tmpl
@@ -862,7 +862,7 @@
             <article>
                 <iframe frameborder="0" style="border:0"
                     src="https://www.google.com/maps/embed/v1/place?q=place_id:Eio0LzE4IENpcmN1aXQgRHIsIEhlbmRvbiBTQSA1MDE0LCBBdXN0cmFsaWE&key=${GOOGLE_MAPS_API_KEY}"
-                    allowfullscreen referrerpolicy="no-referrer" loading="lazy"></iframe>
+                    allowfullscreen referrerpolicy="strict-origin-when-cross-origin" loading="lazy"></iframe>
             </article>
         </div>
 

--- a/deployed_site/index.html.tmpl
+++ b/deployed_site/index.html.tmpl
@@ -244,7 +244,7 @@
 			</article>
 			<article>
 				<iframe frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=place_id:Eio0LzE4IENpcmN1aXQgRHIsIEhlbmRvbiBTQSA1MDE0LCBBdXN0cmFsaWE&key=${GOOGLE_MAPS_API_KEY}"
-				    allowfullscreen referrerpolicy="no-referrer" loading="lazy"></iframe>
+				    allowfullscreen referrerpolicy="strict-origin-when-cross-origin" loading="lazy"></iframe>
 			</article>
 		</div>
 	</section>


### PR DESCRIPTION
## Summary

Change `referrerpolicy` attribute from `no-referrer` to `strict-origin-when-cross-origin` on Maps Embed iframe tags to comply with Google's July 23, 2026 deadline.

## Why

Google Maps Embed API key restrictions (website, app, IP) are currently bypassed when requests lack a Referrer header. The `no-referrer` policy explicitly strips this header. After July 23, 2026, Google will strictly enforce referrer validation, causing embedded maps to fail if this header is missing.

The `strict-origin-when-cross-origin` policy sends the request origin as the referrer for cross-origin requests, satisfying the API key's website restriction check.

## Changes

- `deployed_site/index.html.tmpl` (line 247): Updated referrerpolicy
- `deployed_site/gallery.html.tmpl` (line 865): Updated referrerpolicy

## Test Plan

- ✅ Docker containers built and running
- ✅ Both pages load successfully (200 OK)
- ✅ Maps iframes render with correct referrerpolicy attribute
- ✅ Browser will send Referer header for cross-origin requests