### PR TITLE
Add deployment script for GoDaddy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load env vars from .env
+set -a; source .env; set +a
+
+GODADDY_USER="your_ssh_user"
+GODADDY_HOST="your_host"        # e.g. ssh.example.com or IP
+GODADDY_PATH="/path/to/public_html"
+
+# Generate final HTML from templates (same substitutions as entrypoint.sh)
+envsubst '${GOOGLE_MAPS_API_KEY} ${RECAPTCHA_SITE_KEY}' \
+  < deployed_site/index.html.tmpl > deployed_site/index.html
+
+envsubst '${GOOGLE_MAPS_API_KEY}' \
+  < deployed_site/gallery.html.tmpl > deployed_site/gallery.html
+
+# SCP everything except templates, .env, and local-only files
+scp -r deployed_site/assets \
+        deployed_site/images \
+        deployed_site/recaptcha-master \
+        deployed_site/contact.php \
+        deployed_site/index.html \
+        deployed_site/gallery.html \
+        "${GODADDY_USER}@${GODADDY_HOST}:${GODADDY_PATH}/"
+
+echo "Deploy complete."


### PR DESCRIPTION
## Summary
Adds `deploy.sh` to automate SCP deployment to GoDaddy with proper env var substitution.

The script:
- Loads env vars from `.env` locally
- Runs `envsubst` on HTML templates to bake in `GOOGLE_MAPS_API_KEY` and `RECAPTCHA_SITE_KEY`
- SCPs the rendered site files to GoDaddy (excluding templates and `.env`)

Runtime vars (`RECAPTCHA_SECRET_KEY`, `ENQUIRY_EMAIL`) are configured via `.htaccess` on the server.

## Test plan
- [ ] Fill in `GODADDY_USER`, `GODADDY_HOST`, `GODADDY_PATH` in `deploy.sh`
- [ ] Verify `.htaccess` is set up on GoDaddy with correct secret key
- [ ] Run `./deploy.sh` and confirm no errors
- [ ] SSH into GoDaddy and verify `index.html`/`gallery.html` contain real API key values
- [ ] Test Google Maps embed loads on live site
- [ ] Test contact form submission sends email