### PR TITLE
Fix CLAUDE.md: correct RECAPTCHA_BYPASS documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ docker-compose up --build  # Rebuild after Dockerfile changes
 - `php.ini` — routes `mail()` calls through msmtp → mailhog in dev
 
 **Contact form** (`deployed_site/contact.php`):
-- ReCAPTCHA v2 validation (bypass in dev: set `RECAPTCHA_BYPASS=true` in `.env`)
+- ReCAPTCHA v2 validation (bypassed in dev — `docker-compose.yml` hardcodes `RECAPTCHA_BYPASS=true` for the `web` service)
 - CSRF protection via origin/referer check
 - Email sent via `mail()` → msmtp → mailhog
 


### PR DESCRIPTION
## Summary
- Audited CLAUDE.md against current code on `master` (Dockerfile, entrypoint.sh, docker-compose.yml, contact.php, deploy.sh, deploy-images.sh, .env.example) — everything else matches.
- Fixed one inaccuracy: CLAUDE.md said to bypass ReCAPTCHA in dev by setting `RECAPTCHA_BYPASS=true` in `.env`, but it's actually hardcoded in `docker-compose.yml` for the `web` service and never read from `.env`.

## Test plan
- [x] Read-only doc fix, no runtime behavior change