### PR TITLE
Convert inline contact form to a Bootstrap modal

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -20,7 +20,7 @@ GODADDY_PATH="public_html"
 envsubst '${GOOGLE_MAPS_API_KEY} ${RECAPTCHA_SITE_KEY}' \
   < deployed_site/index.html.tmpl > deployed_site/index.html
 
-envsubst '${GOOGLE_MAPS_API_KEY}' \
+envsubst '${GOOGLE_MAPS_API_KEY} ${RECAPTCHA_SITE_KEY}' \
   < deployed_site/gallery.html.tmpl > deployed_site/gallery.html
 
 # SCP everything except templates, .env, and local-only files

--- a/deployed_site/assets/css/main.css
+++ b/deployed_site/assets/css/main.css
@@ -4216,6 +4216,11 @@ body.modal-open {
 	font-size: 0.9em;
 }
 
+.alert:focus {
+	outline: 0;
+	box-shadow: 0 0 0 1px #e5474b;
+}
+
 .alert-success {
 	background-color: #eaf7ec;
 	color: #2d7a3e;

--- a/deployed_site/assets/css/main.css
+++ b/deployed_site/assets/css/main.css
@@ -3101,8 +3101,8 @@ body {
 	background-repeat: no-repeat;
 	background-size: contain;
 	max-width: 65em;
-	width: calc(100% - 0.75em);
-	margin: 0;
+	width: calc(100% - 6em);
+	margin: 0 auto;
 	max-height: inherit;
 	position: relative;
 }
@@ -3114,7 +3114,7 @@ body {
 		background: url("../../images/logo_300x80.gif");
 		background-repeat: no-repeat;
 		background-size: contain;
-		margin: 0;
+		margin: 0 auto;
 	}
 }
 
@@ -3123,7 +3123,7 @@ body {
 		background: url("../../images/logo_329x80.gif");
 		background-repeat: no-repeat;
 		background-size: contain;
-		margin: 0;
+		margin: 0 auto;
 	}
 }
 

--- a/deployed_site/assets/css/main.css
+++ b/deployed_site/assets/css/main.css
@@ -1488,10 +1488,18 @@ body {
 body {
 	background: #ffffff;
 	overflow-x: hidden;
-	/* Reserve the scrollbar's width permanently so toggling body.modal-open's
-	   overflow (which removes the scrollbar) doesn't change the page's
-	   available width and shift fixed/centered content sideways. */
-	scrollbar-gutter: stable;
+}
+
+@media screen and (min-width: 981px) {
+	body {
+		/* Reserve the scrollbar's width permanently so toggling body.modal-open's
+		   overflow (which removes the scrollbar) doesn't change the page's
+		   available width and shift fixed/centered content sideways. Scoped to
+		   desktop widths that actually render a space-consuming scrollbar —
+		   real phones use overlay scrollbars and don't need this, and reserving
+		   it unconditionally shifted the modal off-center on narrow viewports. */
+		scrollbar-gutter: stable;
+	}
 }
 
 body.is-loading *,

--- a/deployed_site/assets/css/main.css
+++ b/deployed_site/assets/css/main.css
@@ -4089,16 +4089,16 @@ body.modal-open {
 	outline: 0;
 }
 
-.modal.fade .modal-dialog {
-	-moz-transition: -moz-transform 0.2s ease-out;
-	-webkit-transition: -webkit-transform 0.2s ease-out;
-	-ms-transition: -ms-transform 0.2s ease-out;
-	transition: transform 0.2s ease-out;
-	transform: translate(0, -25%);
+.modal.fade {
+	opacity: 0;
+	-moz-transition: opacity 0.15s linear;
+	-webkit-transition: opacity 0.15s linear;
+	-ms-transition: opacity 0.15s linear;
+	transition: opacity 0.15s linear;
 }
 
-.modal.in .modal-dialog {
-	transform: translate(0, 0);
+.modal.in {
+	opacity: 1;
 }
 
 .modal-open .modal {
@@ -4188,6 +4188,10 @@ body.modal-open {
 
 .modal-backdrop.fade {
 	opacity: 0;
+	-moz-transition: opacity 0.15s linear;
+	-webkit-transition: opacity 0.15s linear;
+	-ms-transition: opacity 0.15s linear;
+	transition: opacity 0.15s linear;
 }
 
 .modal-backdrop.in {

--- a/deployed_site/assets/css/main.css
+++ b/deployed_site/assets/css/main.css
@@ -4069,3 +4069,182 @@ div.gal {
 			font-size: 24px;
 			line-height: inherit;
 		}
+
+
+/* Modal */
+
+body.modal-open {
+	overflow: hidden;
+}
+
+.modal {
+	display: none;
+	position: fixed;
+	top: 0;
+	left: 0;
+	z-index: 10010;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	outline: 0;
+}
+
+.modal.fade .modal-dialog {
+	-moz-transition: -moz-transform 0.2s ease-out;
+	-webkit-transition: -webkit-transform 0.2s ease-out;
+	-ms-transition: -ms-transform 0.2s ease-out;
+	transition: transform 0.2s ease-out;
+	transform: translate(0, -25%);
+}
+
+.modal.in .modal-dialog {
+	transform: translate(0, 0);
+}
+
+.modal-open .modal {
+	overflow-x: hidden;
+	overflow-y: auto;
+}
+
+.modal-dialog {
+	position: relative;
+	width: 90%;
+	max-width: 34em;
+	margin: 5em auto;
+}
+
+.modal-content {
+	position: relative;
+	background-color: #ffffff;
+	border-radius: 4px;
+	box-shadow: 0 0.5em 2em 0 rgba(0, 0, 0, 0.3);
+	color: #4d4d4d;
+}
+
+.modal-header {
+	padding: 1.25em 1.5em;
+	border-bottom: solid 1px #e5e5e5;
+}
+
+.modal-header .close {
+	float: right;
+	margin-top: -0.15em;
+}
+
+.modal-title {
+	margin: 0;
+	color: #4d4d4d;
+	font-size: 1.35em;
+	font-weight: 700;
+}
+
+.modal-body {
+	padding: 1.5em;
+}
+
+.modal-body form {
+	margin: 0;
+}
+
+.modal-footer {
+	padding: 1em 1.5em;
+	border-top: solid 1px #e5e5e5;
+	text-align: right;
+}
+
+.modal .close {
+	display: inline-block;
+	float: right;
+	width: 1.5em;
+	height: 1.5em;
+	line-height: 1.4em;
+	text-align: center;
+	background: none;
+	border: 0;
+	padding: 0;
+	cursor: pointer;
+	color: #4d4d4d;
+	opacity: 0.5;
+	font-size: 1.5em;
+	font-weight: 300;
+	text-decoration: none;
+}
+
+.modal .close:hover {
+	opacity: 1;
+	color: #e5474b;
+	text-decoration: none;
+}
+
+.modal-backdrop {
+	position: fixed;
+	top: 0;
+	left: 0;
+	z-index: 10005;
+	width: 100%;
+	height: 100%;
+	background-color: #000000;
+}
+
+.modal-backdrop.fade {
+	opacity: 0;
+}
+
+.modal-backdrop.in {
+	opacity: 0.6;
+}
+
+@media screen and (max-width: 480px) {
+	.modal-dialog {
+		width: 94%;
+		margin: 2em auto;
+	}
+
+	.modal-body {
+		padding: 1.25em;
+	}
+}
+
+
+/* Alert */
+
+.alert {
+	position: relative;
+	padding: 0.85em 2.25em 0.85em 1em;
+	margin: 0 0 1.5em 0;
+	border-radius: 4px;
+	font-size: 0.9em;
+}
+
+.alert-success {
+	background-color: #eaf7ec;
+	color: #2d7a3e;
+	border: solid 1px #c3e6cb;
+}
+
+.alert-danger {
+	background-color: #fceced;
+	color: #b3282d;
+	border: solid 1px #f5c2c4;
+}
+
+.alert .close {
+	display: inline-block;
+	position: absolute;
+	top: 0.6em;
+	right: 0.6em;
+	background: none;
+	border: 0;
+	padding: 0;
+	cursor: pointer;
+	color: inherit;
+	opacity: 0.6;
+	font-size: 1.1em;
+	line-height: 1;
+	text-decoration: none;
+}
+
+.alert .close:hover {
+	opacity: 1;
+	text-decoration: none;
+}

--- a/deployed_site/assets/css/main.css
+++ b/deployed_site/assets/css/main.css
@@ -1488,6 +1488,10 @@ body {
 body {
 	background: #ffffff;
 	overflow-x: hidden;
+	/* Reserve the scrollbar's width permanently so toggling body.modal-open's
+	   overflow (which removes the scrollbar) doesn't change the page's
+	   available width and shift fixed/centered content sideways. */
+	scrollbar-gutter: stable;
 }
 
 body.is-loading *,

--- a/deployed_site/assets/js/contact.js
+++ b/deployed_site/assets/js/contact.js
@@ -12,14 +12,21 @@ $(function () {
                 data: $(this).serialize(),
                 success: function (data)
                 {
+                    if (data.type === 'success') {
+                        $('#contact-form').find('.messages').empty();
+                        $('#contact-form')[0].reset();
+                        grecaptcha.reset();
+                        $('#contactModal').modal('hide');
+                        $('#successModal').modal('show');
+                        return;
+                    }
+
                     var messageAlert = 'alert-' + data.type;
                     var messageText = data.message;
 
-                    var alertBox = '<div class="alert ' + messageAlert + ' alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>' + messageText + '</div>';
+                    var alertBox = '<div class="alert ' + messageAlert + ' alert-dismissable"><a href="#" class="close" data-dismiss="alert" aria-hidden="true">&times;</a>' + messageText + '</div>';
                     if (messageAlert && messageText) {
                         $('#contact-form').find('.messages').html(alertBox);
-                        $('#contact-form')[0].reset();
-                        grecaptcha.reset();
                     }
                 }
             });

--- a/deployed_site/assets/js/contact.js
+++ b/deployed_site/assets/js/contact.js
@@ -1,5 +1,20 @@
 $(function () {
 
+    // The off-canvas #navPanel (see main.js) stops all clicks inside it from
+    // bubbling (util.js panel plugin), which stops Bootstrap's document-level
+    // [data-toggle="modal"] handler from ever seeing the click. Bind directly
+    // on #navPanel instead so it isn't blocked by that same stopPropagation.
+    $('#navPanel').on('click', 'a[data-toggle="modal"]', function (e) {
+        e.preventDefault();
+
+        var target = $(this).attr('data-target');
+
+        $('#navPanel').removeClass('visible');
+        window.setTimeout(function () {
+            $(target).modal('show');
+        }, 500);
+    });
+
     $('#contact-form').validator();
 
     $('#contact-form').on('submit', function (e) {

--- a/deployed_site/assets/js/contact.js
+++ b/deployed_site/assets/js/contact.js
@@ -24,9 +24,11 @@ $(function () {
                     var messageAlert = 'alert-' + data.type;
                     var messageText = data.message;
 
-                    var alertBox = '<div class="alert ' + messageAlert + ' alert-dismissable"><a href="#" class="close" data-dismiss="alert" aria-hidden="true">&times;</a>' + messageText + '</div>';
+                    var alertBox = '<div class="alert ' + messageAlert + ' alert-dismissable" tabindex="-1"><a href="#" class="close" data-dismiss="alert" aria-hidden="true">&times;</a>' + messageText + '</div>';
                     if (messageAlert && messageText) {
-                        $('#contact-form').find('.messages').html(alertBox);
+                        var $alert = $('#contact-form').find('.messages').html(alertBox).find('.alert');
+                        $alert[0].scrollIntoView({ block: 'start', behavior: 'smooth' });
+                        $alert.focus();
                     }
                 }
             });

--- a/deployed_site/gallery.html.tmpl
+++ b/deployed_site/gallery.html.tmpl
@@ -24,7 +24,7 @@
             <nav id="nav">
                 <a href="index.html">Home</a>
                 <a href="gallery.html">Gallery</a>
-                <a href="index.html#contact">Contact Us</a>
+                <a href="#" data-toggle="modal" data-target="#contactModal">Contact Us</a>
             </nav>
         </div>
     </header>
@@ -931,6 +931,88 @@
             </div>
 
         </div>
+
+        <!-- Contact modal -->
+        <div class="modal fade" id="contactModal" tabindex="-1" role="dialog" aria-labelledby="contactModalLabel">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <a href="#" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+                        <h2 class="modal-title" id="contactModalLabel">Get in Touch</h2>
+                    </div>
+                    <div class="modal-body">
+                        <form id="contact-form" method="post" action="contact.php" role="form">
+                            <div class="messages"></div>
+
+                            <div class="controls">
+                                <div class="field">
+                                    <div class="field half first form-group">
+                                        <label for="form_name">Firstname *</label>
+                                        <input id="form_name" type="text" name="name" class="form-control" placeholder="Please enter your firstname *" required="required"
+                                            data-error="Firstname is required.">
+                                        <div class="help-block with-errors"></div>
+                                    </div>
+                                    <div class="field half form-group">
+                                        <label for="form_lastname">Lastname *</label>
+                                        <input id="form_lastname" type="text" name="surname" class="form-control" placeholder="Please enter your lastname *" required="required"
+                                            data-error="Lastname is required.">
+                                        <div class="help-block with-errors"></div>
+                                    </div>
+                                </div>
+                                <div class="field half first form-group">
+                                    <label for="form_email">Email *</label>
+                                    <input id="form_email" type="email" name="email" class="form-control" placeholder="Please enter your email *" required="required"
+                                        data-error="Valid email is required.">
+                                    <div class="help-block with-errors"></div>
+                                </div>
+                                <div class="field half form-group">
+                                    <label for="form_phone">Phone</label>
+                                    <input id="form_phone" type="tel" name="phone" class="form-control" placeholder="Please enter your phone">
+                                    <div class="help-block with-errors"></div>
+                                </div>
+                                <div class="field form-group">
+                                    <label for="form_message">Message *</label>
+                                    <textarea id="form_message" name="message" class="form-control" placeholder="Message for me *" rows="5" required="required"
+                                        data-error="Please,leave us a message."></textarea>
+                                    <div class="help-block with-errors"></div>
+                                </div>
+
+                                <div class="field form-group">
+                                    <div class="g-recaptcha" data-sitekey="${RECAPTCHA_SITE_KEY}"></div>
+                                </div>
+
+                                <div class="field actions">
+                                    <input type="submit" class="alt" value="Send message">
+                                </div>
+                            </div>
+                            <div class="field">
+                                <p class="text-muted">
+                                    <strong>*</strong> These fields are required.</p>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Success modal -->
+        <div class="modal fade" id="successModal" tabindex="-1" role="dialog" aria-labelledby="successModalLabel">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <a href="#" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+                        <h2 class="modal-title" id="successModalLabel">Thank you</h2>
+                    </div>
+                    <div class="modal-body">
+                        <p>Contact form successfully submitted. Thank you, I will get back to you soon!</p>
+                    </div>
+                    <div class="modal-footer">
+                        <input type="button" class="alt" value="Close" data-dismiss="modal">
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Scripts -->
         <script src="assets/js/jquery.min.js"></script>
         <script src="assets/js/skel.min.js"></script>
@@ -939,6 +1021,10 @@
         <script src="assets/js/dist/photoswipe.min.js"></script>
         <script src="assets/js/dist/photoswipe-ui-default.min.js"></script>
         <script src="assets/js/ps.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+        <script src='https://www.google.com/recaptcha/api.js'></script>
+        <script src="assets/js/validator.js"></script>
+        <script src="assets/js/contact.js"></script>
 </body>
 
 </html>

--- a/deployed_site/index.html.tmpl
+++ b/deployed_site/index.html.tmpl
@@ -26,7 +26,7 @@
 			<nav id="nav">
 				<a href="index.html">Home</a>
 				<a href="gallery.html">Gallery</a>
-				<a href="#contact">Contact Us</a>
+				<a href="#" data-toggle="modal" data-target="#contactModal">Contact Us</a>
 			</nav>
 		</div>
 	</header>
@@ -68,7 +68,7 @@
 				by appointment only.</p>
 			<ul class="actions">
 				<li>
-					<a href="#contact" class="button alt">Contact Us</a>
+					<a href="#" class="button alt" data-toggle="modal" data-target="#contactModal">Contact Us</a>
 				</li>
 				<li>
 					<a href="gallery.html" class="button alt">Gallery</a>
@@ -76,7 +76,7 @@
 			</ul>
 			<p>We have
 				<b>
-					<a href="#contact">MOVED</a>
+					<a href="#" data-toggle="modal" data-target="#contactModal">MOVED</a>
 				</b> to our new workshop at: 4/18 Circuit Drive, Hendon SA 5014</p>
 			<div class="box alt">
 				<div class="row 50% uniform">
@@ -252,63 +252,92 @@
 	<!-- Footer -->
 	<section id="footer">
 		<div class="inner">
-			<header>
-				<h2>Get in Touch</h2>
-			</header>
-			<form id="contact-form" method="post" action="contact.php" role="form">
-				<div class="messages"></div>
-
-				<div class="controls">
-					<div class="field">
-						<div class="field half first form-group">
-							<label for="form_name">Firstname *</label>
-							<input id="form_name" type="text" name="name" class="form-control" placeholder="Please enter your firstname *" required="required"
-							    data-error="Firstname is required.">
-							<div class="help-block with-errors"></div>
-						</div>
-						<div class="field half form-group">
-							<label for="form_lastname">Lastname *</label>
-							<input id="form_lastname" type="text" name="surname" class="form-control" placeholder="Please enter your lastname *" required="required"
-							    data-error="Lastname is required.">
-							<div class="help-block with-errors"></div>
-						</div>
-					</div>
-					<div class="field half first form-group">
-						<label for="form_email">Email *</label>
-						<input id="form_email" type="email" name="email" class="form-control" placeholder="Please enter your email *" required="required"
-						    data-error="Valid email is required.">
-						<div class="help-block with-errors"></div>
-					</div>
-					<div class="field half form-group">
-						<label for="form_phone">Phone</label>
-						<input id="form_phone" type="tel" name="phone" class="form-control" placeholder="Please enter your phone">
-						<div class="help-block with-errors"></div>
-					</div>
-					<div class="field form-group">
-						<label for="form_message">Message *</label>
-						<textarea id="form_message" name="message" class="form-control" placeholder="Message for me *" rows="5" required="required"
-						    data-error="Please,leave us a message."></textarea>
-						<div class="help-block with-errors"></div>
-					</div>
-
-					<div class="field form-group">
-						<div class="g-recaptcha" data-sitekey="${RECAPTCHA_SITE_KEY}"></div>
-					</div>
-
-					<div class="field actions">
-						<input type="submit" class="alt" value="Send message">
-					</div>
-				</div>
-				<div class="field">
-					<p class="text-muted">
-						<strong>*</strong> These fields are required.</p>
-				</div>
-			</form>
 			<div class="copyright">
 				&copy; Scheff&apos;s Kitchens &amp; Cabinets - 2026
 			</div>
 		</div>
 	</section>
+
+	<!-- Contact modal -->
+	<div class="modal fade" id="contactModal" tabindex="-1" role="dialog" aria-labelledby="contactModalLabel">
+		<div class="modal-dialog" role="document">
+			<div class="modal-content">
+				<div class="modal-header">
+					<a href="#" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+					<h2 class="modal-title" id="contactModalLabel">Get in Touch</h2>
+				</div>
+				<div class="modal-body">
+					<form id="contact-form" method="post" action="contact.php" role="form">
+						<div class="messages"></div>
+
+						<div class="controls">
+							<div class="field">
+								<div class="field half first form-group">
+									<label for="form_name">Firstname *</label>
+									<input id="form_name" type="text" name="name" class="form-control" placeholder="Please enter your firstname *" required="required"
+									    data-error="Firstname is required.">
+									<div class="help-block with-errors"></div>
+								</div>
+								<div class="field half form-group">
+									<label for="form_lastname">Lastname *</label>
+									<input id="form_lastname" type="text" name="surname" class="form-control" placeholder="Please enter your lastname *" required="required"
+									    data-error="Lastname is required.">
+									<div class="help-block with-errors"></div>
+								</div>
+							</div>
+							<div class="field half first form-group">
+								<label for="form_email">Email *</label>
+								<input id="form_email" type="email" name="email" class="form-control" placeholder="Please enter your email *" required="required"
+								    data-error="Valid email is required.">
+								<div class="help-block with-errors"></div>
+							</div>
+							<div class="field half form-group">
+								<label for="form_phone">Phone</label>
+								<input id="form_phone" type="tel" name="phone" class="form-control" placeholder="Please enter your phone">
+								<div class="help-block with-errors"></div>
+							</div>
+							<div class="field form-group">
+								<label for="form_message">Message *</label>
+								<textarea id="form_message" name="message" class="form-control" placeholder="Message for me *" rows="5" required="required"
+								    data-error="Please,leave us a message."></textarea>
+								<div class="help-block with-errors"></div>
+							</div>
+
+							<div class="field form-group">
+								<div class="g-recaptcha" data-sitekey="${RECAPTCHA_SITE_KEY}"></div>
+							</div>
+
+							<div class="field actions">
+								<input type="submit" class="alt" value="Send message">
+							</div>
+						</div>
+						<div class="field">
+							<p class="text-muted">
+								<strong>*</strong> These fields are required.</p>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- Success modal -->
+	<div class="modal fade" id="successModal" tabindex="-1" role="dialog" aria-labelledby="successModalLabel">
+		<div class="modal-dialog" role="document">
+			<div class="modal-content">
+				<div class="modal-header">
+					<a href="#" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+					<h2 class="modal-title" id="successModalLabel">Thank you</h2>
+				</div>
+				<div class="modal-body">
+					<p>Contact form successfully submitted. Thank you, I will get back to you soon!</p>
+				</div>
+				<div class="modal-footer">
+					<input type="button" class="alt" value="Close" data-dismiss="modal">
+				</div>
+			</div>
+		</div>
+	</div>
 
 	<!-- Scripts -->
 	<script src="assets/js/jquery.min.js"></script>

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 envsubst '${GOOGLE_MAPS_API_KEY} ${RECAPTCHA_SITE_KEY}' \
   < /var/www/html/index.html.tmpl > /var/www/html/index.html
 
-envsubst '${GOOGLE_MAPS_API_KEY}' \
+envsubst '${GOOGLE_MAPS_API_KEY} ${RECAPTCHA_SITE_KEY}' \
   < /var/www/html/gallery.html.tmpl > /var/www/html/gallery.html
 
 exec apache2-foreground


### PR DESCRIPTION
## Summary
- "Contact Us" (nav + CTA links) now opens a Bootstrap-JS-driven modal containing the contact form, on both `index.html` and `gallery.html`. Gallery previously had no form at all, just a link back to `index.html#contact`.
- Successful submission closes the contact modal and shows a dedicated "Thank you" success modal (verified against Mailhog); failed submissions keep the existing inline alert behavior inside the still-open modal.
- No Bootstrap CSS is loaded sitewide (only its JS was already vendored, for `validator.js`) — added a small scoped CSS block in `main.css` matching Bootstrap 3's modal/alert markup so the design stays consistent with the rest of the site instead of pulling in Bootstrap's global stylesheet.
- `docker/entrypoint.sh` and `deploy.sh` now also substitute `RECAPTCHA_SITE_KEY` into `gallery.html.tmpl` (previously only `index.html.tmpl` did), since the gallery page's modal now embeds its own recaptcha widget.
- Modal close controls use `<a>` instead of `<button>` — the site has a global `button { color: #ffffff !important; height: 3.5em; ... }` reset that clobbered a `<button class="close">`'s sizing/color; matches the existing `#navPanel .close` pattern already in the codebase.

## Test plan
- [x] `docker-compose up`, drove both pages end-to-end with Playwright: click Contact Us → modal opens → fill + submit → contact modal closes, success modal shows → email captured in Mailhog (verified via Mailhog API).
- [x] Verified the error path (mocked a `danger` response) — inline alert renders inside the still-open modal, matches site's red/pink palette.
- [x] Checked mobile viewport (375px) — modal fills width appropriately, all fields usable, close button visible.
- [x] Confirmed `RECAPTCHA_SITE_KEY` is now substituted into `gallery.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)